### PR TITLE
Configurable test patterns

### DIFF
--- a/lua/neotest-mocha/util.lua
+++ b/lua/neotest-mocha/util.lua
@@ -352,9 +352,9 @@ function M.create_test_file_extensions_matcher(intermediate_extensions, end_exte
       return true
     end
 
-    for _, x in ipairs(intermediate_extensions) do
-      for _, ext in ipairs(end_extensions) do
-        if string.match(file_path, x .. "%." .. ext .. "$") then
+    for _, iext in ipairs(intermediate_extensions) do
+      for _, eext in ipairs(end_extensions) do
+        if string.match(file_path, iext .. "%." .. eext .. "$") then
           return true
         end
       end

--- a/lua/neotest-mocha/util.lua
+++ b/lua/neotest-mocha/util.lua
@@ -339,6 +339,9 @@ function M.parsed_json_to_results(data, tree, consoleOut)
   return tests
 end
 
+---@param intermediate_extensions Array
+---@param end_extensions Array
+---@return function
 function M.create_test_file_extensions_matcher(intermediate_extensions, end_extensions)
   return function(file_path)
     if file_path == nil then

--- a/lua/neotest-mocha/util.lua
+++ b/lua/neotest-mocha/util.lua
@@ -339,4 +339,26 @@ function M.parsed_json_to_results(data, tree, consoleOut)
   return tests
 end
 
+function M.create_test_file_extensions_matcher(intermediate_extensions, end_extensions)
+  return function(file_path)
+    if file_path == nil then
+      return false
+    end
+
+    if string.match(file_path, "test") then
+      return true
+    end
+
+    for _, x in ipairs(intermediate_extensions) do
+      for _, ext in ipairs(end_extensions) do
+        if string.match(file_path, x .. "%." .. ext .. "$") then
+          return true
+        end
+      end
+    end
+
+    return false
+  end
+end
+
 return M

--- a/test/basic_spec.lua
+++ b/test/basic_spec.lua
@@ -5,6 +5,7 @@ local MockTree = require "test.helpers.mock_tree"
 local plugin = require "neotest-mocha" {
   mochaCommand = "mocha",
 }
+local util = require "neotest-mocha.util"
 
 describe("is_test_file", function()
   local supported_extensions = { "js", "mjs", "cjs", "jsx", "coffee", "ts", "tsx" }
@@ -23,6 +24,26 @@ describe("is_test_file", function()
 
   it("does not match non-test files", function()
     assert.False(plugin.is_test_file "./src/index.js")
+  end)
+
+  it("matches mocha test files with configurable test patterns", function()
+    local intermediate_extensions = { "spec", "test", "lollipop" }
+    local is_test_file = util.create_test_file_extensions_matcher(
+      intermediate_extensions,
+      supported_extensions
+    )
+
+    -- by folder name.
+    for _, extension in ipairs(supported_extensions) do
+      assert.True(is_test_file("./test/basic." .. extension))
+    end
+
+    -- by file name.
+    for _, extension1 in ipairs(intermediate_extensions) do
+      for _, extension2 in ipairs(supported_extensions) do
+        assert.True(is_test_file("./src/basic." .. extension1 .. "." .. extension2))
+      end
+    end
   end)
 end)
 


### PR DESCRIPTION
As discussed in #1, this PR adds the ability to configure the file extensions for test files. I also added a utility function `create_test_file_extensions_matcher` for easily creating a matcher from a set of file extensions as in:

```lua
local neotest = require('neotest')
local mocha_util = require('neotest-mocha.util')

neotest.setup({
  is_test_file = mocha_util.create_test_file_extensions_matcher(
    { 'spec', 'test' },
    { 'js', 'mjs', 'cjs', 'jsx', 'coffee', 'ts', 'tsx' }
  ),
})
```