### PR TITLE
feat: parse non arrow functions in namespaces and test

### DIFF
--- a/lua/neotest-mocha/init.lua
+++ b/lua/neotest-mocha/init.lua
@@ -55,28 +55,28 @@ function Adapter.discover_positions(file_path)
     ; Matches: `describe('context')`
     ((call_expression
       function: (identifier) @func_name (#any-of? @func_name "describe" "context")
-      arguments: (arguments (string (string_fragment) @namespace.name) (arrow_function))
+      arguments: (arguments (string (string_fragment) @namespace.name) [(function) (arrow_function)])
     )) @namespace.definition
     ; Matches: `describe.only('context')`
     ((call_expression
       function: (member_expression
         object: (identifier) @func_name (#any-of? @func_name "describe" "context")
       )
-      arguments: (arguments (string (string_fragment) @namespace.name) (arrow_function))
+      arguments: (arguments (string (string_fragment) @namespace.name) [(function) (arrow_function)])
     )) @namespace.definition
 
     ; -- Tests --
     ; Matches: `it('test') / specify('test')`
     ((call_expression
       function: (identifier) @func_name (#any-of? @func_name "it" "specify")
-      arguments: (arguments (string (string_fragment) @test.name) (arrow_function))
+      arguments: (arguments (string (string_fragment) @test.name) [(function) (arrow_function)])
     )) @test.definition
     ; Matches: `it.only('test') / specify.only('test')`
     ((call_expression
       function: (member_expression
         object: (identifier) @func_name (#any-of? @func_name "it" "specify")
       )
-      arguments: (arguments (string (string_fragment) @test.name) (arrow_function))
+      arguments: (arguments (string (string_fragment) @test.name) [(function) (arrow_function)])
     )) @test.definition
   ]]
 

--- a/test/specs/basic.test.js
+++ b/test/specs/basic.test.js
@@ -8,7 +8,7 @@ describe("describe suite", () => {
     assert.ok(true);
   });
 
-  it("should fail", () => {
+  it("should fail", function () {
     console.log("it should fail");
     assert.ok(false);
   });
@@ -17,7 +17,7 @@ describe("describe suite", () => {
     // noop
   });
 
-  describe("nested suite", () => {
+  describe("nested suite", function() {
     it("should pass", () => {
       assert.ok(true);
     });
@@ -41,7 +41,7 @@ context("context suite", () => {
   });
 
   context("nested suite", () => {
-    specify("should pass", () => {
+    specify("should pass", async function() {
       assert.ok(true);
     });
   })


### PR DESCRIPTION
The parser is not detecting the namespaces and tests if functions are used instead of arrow functions, the below items are not detected.

```javascript
describe('block', function (){
...
})
```

```javascript
it('block', function (){
...
})

```


I changed the treesitter querries to accommodate non arrow functions. 


Unfortunately, I do not know how to run the test, tried `lua test/basic_spec.lua`, it did not work. However, the changes do work as expected, I tested these changes in neovim. Kindly give some guidance on testing or please feel free to takeover.


