### PR TITLE
feat: allow to use backticks in test messages

### DIFF
--- a/test/fixtures/basic_test_positions.lua
+++ b/test/fixtures/basic_test_positions.lua
@@ -3,7 +3,7 @@ return {
     id = "./test/specs/basic.test.js",
     name = "basic.test.js",
     path = "./test/specs/basic.test.js",
-    range = { 0, 0, 69, 0 },
+    range = { 0, 0, 80, 0 },
     type = "file",
   },
   {
@@ -165,6 +165,33 @@ return {
           range = { 64, 4, 66, 6 },
           type = "test",
         },
+      },
+    },
+  },
+  {
+    {
+      id = "./test/specs/basic.test.js::backtick suite",
+      name = "backtick suite",
+      path = "./test/specs/basic.test.js",
+      range = { 70, 0, 79, 2 },
+      type = "namespace",
+    },
+    {
+      {
+        id = "./test/specs/basic.test.js::backtick suite::`backticks text`",
+        name = "`backticks text`",
+        path = "./test/specs/basic.test.js",
+        range = { 71, 2, 73, 4 },
+        type = "test",
+      },
+    },
+    {
+      {
+        id = "./test/specs/basic.test.js::backtick suite::`backticks text with variable: ${variable}`",
+        name = "`backticks text with variable: ${variable}`",
+        path = "./test/specs/basic.test.js",
+        range = { 76, 2, 78, 4 },
+        type = "test",
       },
     },
   },

--- a/test/specs/basic.test.js
+++ b/test/specs/basic.test.js
@@ -67,3 +67,14 @@ context("context suite", () => {
     });
   })
 });
+
+describe("backtick suite", () => {
+  it(`backticks text`, () => {
+    assert.ok(true)
+  });
+
+  const variable = 'some value'
+  it(`backticks text with variable: ${variable}`, () => {
+    assert.ok(true)
+  })
+})


### PR DESCRIPTION
## What?

Allow to use backticks  in the message test of the it

## Why?

Right now the tests that use backticks in the description of test are not matched by the discover_position function.

When you have descriptions of the test too big you may use ` instead of " or ', this in order to separate in multiple lines the text.

## How?

Based on the PR of neotest-vitest to accomplish the same

https://github.com/marilari88/neotest-vitest/pull/3/files

## Testing?

yes

## Screenshots (optional)

<img width="1291" alt="image" src="https://user-images.githubusercontent.com/75548560/227413729-ce5ecd9c-ffc0-440c-9c72-add5d1ab091d.png">

## Anything Else?

Thank to https://github.com/marilari88 for doing this in the other plugin