### PR TITLE
Check mocha is installed (support monorepos), fix tests

### DIFF
--- a/lua/neotest-mocha/init.lua
+++ b/lua/neotest-mocha/init.lua
@@ -39,7 +39,17 @@ local is_test_file = default_is_test_file
 ---@param file_path string
 ---@return boolean
 function Adapter.is_test_file(file_path)
-  return is_test_file(file_path)
+  local rootPath = util.find_package_json_ancestor(file_path)
+
+  if not rootPath then
+    return false
+  end
+
+  -- This is a test file if it matches the supported extensions and a parent directory
+  -- contains a package.json file with mocha installed. The latter is necessary to
+  -- support monorepos where there are multiple parent directories with a package.json
+  -- and the current file's position in the monorepo has to be taken into account as well
+  return is_test_file(file_path) and util.has_package_dependency(rootPath, "mocha")
 end
 
 ---Filter directories when searching for test files

--- a/lua/neotest-mocha/init.lua
+++ b/lua/neotest-mocha/init.lua
@@ -28,9 +28,6 @@ local Adapter = { name = "neotest-mocha" }
 ---@return string | nil @Absolute root dir of test suite
 Adapter.root = lib.files.match_root_pattern "package.json"
 
----@async
----@param file_path string
----@return boolean
 local default_is_test_file = util.create_test_file_extensions_matcher(
   { "spec", "test" },
   { "js", "mjs", "cjs", "jsx", "coffee", "ts", "tsx" }
@@ -56,13 +53,13 @@ function Adapter.filter_dir(name)
 end
 
 ---@param s string
----@param boolean
+---@return boolean
 local function isTemplateLiteral(s)
   return string.sub(s, 1, 1) == "`"
 end
 
 ---@param s string
----@param string
+---@return string
 local function getStringFromTemplateLiteral(s)
   local matched = string.match(s, "^`(.*)`$")
   if not matched then

--- a/lua/neotest-mocha/util.lua
+++ b/lua/neotest-mocha/util.lua
@@ -383,7 +383,13 @@ function M.has_package_dependency(path, packageName)
     return false
   end
 
-  local packageJsonContent = lib.files.read(fullPath)
+  local ok, packageJsonContent = pcall(lib.files.read, fullPath)
+
+  if not ok then
+    print("cannot read package.json")
+    return false
+  end
+
   local parsedPackageJson = vim.json.decode(packageJsonContent)
 
   if not parsedPackageJson then

--- a/lua/neotest-mocha/util.lua
+++ b/lua/neotest-mocha/util.lua
@@ -339,9 +339,9 @@ function M.parsed_json_to_results(data, tree, consoleOut)
   return tests
 end
 
----@param intermediate_extensions Array
----@param end_extensions Array
----@return function
+---@param intermediate_extensions string[]
+---@param end_extensions string[]
+---@return fun(file_path: string): boolean
 function M.create_test_file_extensions_matcher(intermediate_extensions, end_extensions)
   return function(file_path)
     if file_path == nil then

--- a/lua/neotest-mocha/util.lua
+++ b/lua/neotest-mocha/util.lua
@@ -360,4 +360,43 @@ function M.create_test_file_extensions_matcher(intermediate_extensions, end_exte
   end
 end
 
+---@param dependencies table<string, string>?
+---@param packageName string
+---@return boolean
+local function _has_package_dependency(dependencies, packageName)
+  for key, _ in pairs(dependencies or {}) do
+    if key == packageName then
+      return true
+    end
+  end
+
+  return false
+end
+
+---@param path string
+---@param packageName string
+---@return boolean
+function M.has_package_dependency(path, packageName)
+  if not lib.files.exists(path .. "/package.json") then
+    return false
+  end
+
+  local packageJsonContent = lib.files.read(path .. "/package.json")
+  local parsedPackageJson = vim.json.decode(packageJsonContent)
+
+  if not parsedPackageJson then
+    return false
+  end
+
+  if _has_package_dependency(parsedPackageJson["dependencies"], packageName) then
+    return true
+  end
+
+  if _has_package_dependency(parsedPackageJson["devDependencies"], packageName) then
+    return true
+  end
+
+  return false
+end
+
 return M

--- a/lua/neotest-mocha/util.lua
+++ b/lua/neotest-mocha/util.lua
@@ -387,7 +387,7 @@ function M.has_package_dependency(path, packageName)
   local ok, packageJsonContent = pcall(lib.files.read, fullPath)
 
   if not ok then
-    print("cannot read package.json")
+    print "cannot read package.json"
     return false
   end
 

--- a/lua/neotest-mocha/util.lua
+++ b/lua/neotest-mocha/util.lua
@@ -1,6 +1,7 @@
 local vim = vim
 local validate = vim.validate
 local uv = vim.loop
+local lib = require "neotest.lib"
 
 local M = {}
 

--- a/lua/neotest-mocha/util.lua
+++ b/lua/neotest-mocha/util.lua
@@ -377,11 +377,13 @@ end
 ---@param packageName string
 ---@return boolean
 function M.has_package_dependency(path, packageName)
-  if not lib.files.exists(path .. "/package.json") then
+  local fullPath = path .. "/package.json"
+
+  if not lib.files.exists(fullPath) then
     return false
   end
 
-  local packageJsonContent = lib.files.read(path .. "/package.json")
+  local packageJsonContent = lib.files.read(fullPath)
   local parsedPackageJson = vim.json.decode(packageJsonContent)
 
   if not parsedPackageJson then

--- a/test/basic_spec.lua
+++ b/test/basic_spec.lua
@@ -1,4 +1,4 @@
-local async = require "nio".tests
+local async = require("nio").tests
 local neotest_async = require "neotest.async"
 local basic_test_positions = require "test.fixtures.basic_test_positions"
 local MockTree = require "test.helpers.mock_tree"
@@ -14,7 +14,7 @@ describe("is_test_file", function()
   local has_package_dependency_stub
 
   before_each(function()
-    find_package_json_ancestor_stub = stub(util, "find_package_json_ancestor").returns("./root/")
+    find_package_json_ancestor_stub = stub(util, "find_package_json_ancestor").returns "./root/"
     has_package_dependency_stub = stub(util, "has_package_dependency").returns(true)
   end)
 


### PR DESCRIPTION
This should fix nvim-neotest/neotest#105.

Summary of changes:

* Fixed a few types.
* Refactored `util.has_package_dependency`.
* `Adapter.is_test_file` now finds the root and checks if mocha is installed on *each* test file.
* Updated the tests (let me know if I should add some more).
  - Use `nio.tests` (neotest's own async library) instead of `plenary.async.tests`. This seems to fix the async tests that were failing on upsteam.
  - Removed the tests for recognising test files by folder names since they should not match anymore due to #8.

I tested on a monorepo with the following layout where `app1/` has mocha installed and `app2/` has jest installed. I do not use monorepos and have no experience with them so I hope this covers it.

```
monorepo-test/
└── apps
    ├── app1
    │   ├── node_modules
    │   ├── package-lock.json
    │   ├── package.json
    │   └── test
    │       └── app1.test.js
    └── app2
        ├── node_modules
        ├── package-lock.json
        ├── package.json
        └── test
            └── app2.test.js
```

Everything appears to work except that if I run the file or the single test as the first action, I get the following traceback:

```
Error executing vim.schedule lua callback: /Users/user/.vim-plug/neotest/lua/nio/tasks.lua:95: Async task failed without callback: The coroutine failed with this message:
/Users/user/.vim-plug/neotest/lua/nio/tasks.lua:95: Async task failed without callback: The coroutine failed with this message:
...vim-plug/neotest/lua/neotest/consumers/state/tracker.lua:47: attempt to index local 'tree' (a nil value)
stack traceback:
        ...vim-plug/neotest/lua/neotest/consumers/state/tracker.lua: in function 'is_test'
        ...vim-plug/neotest/lua/neotest/consumers/state/tracker.lua:155: in function 'update_running'
        ...r/.vim-plug/neotest/lua/neotest/consumers/state/init.lua:49: in function 'listener'
        ...ser/.vim-plug/neotest/lua/neotest/client/events/init.lua:51: in function <...ser/.vim-plug/neotest/lua/neotest/client/events/init.lua:47>
stack traceback:
        [C]: in function 'error'
        /Users/user/.vim-plug/neotest/lua/nio/tasks.lua:95: in function 'close_task'
        /Users/user/.vim-plug/neotest/lua/nio/tasks.lua:117: in function 'step'
        /Users/user/.vim-plug/neotest/lua/nio/tasks.lua:145: in function 'run'
        ...ser/.vim-plug/neotest/lua/neotest/client/events/init.lua:47: in function 'emit'
        ...user/.vim-plug/neotest/lua/neotest/client/state/init.lua:95: in function 'update_running'
        /Users/user/.vim-plug/neotest/lua/neotest/client/init.lua:82: in function 'run_tree'
        ...rs/user/.vim-plug/neotest/lua/neotest/consumers/run.lua:73: in function 'func'
        /Users/user/.vim-plug/neotest/lua/nio/tasks.lua:168: in function </Users/user/.vim-plug/neotest/lua/nio/tasks.lua:167>
stack traceback:
        [C]: in function 'error'
        /Users/user/.vim-plug/neotest/lua/nio/tasks.lua:95: in function 'close_task'
        /Users/user/.vim-plug/neotest/lua/nio/tasks.lua:117: in function 'cb'
        /Users/user/.vim-plug/neotest/lua/nio/tasks.lua:181: in function </Users/user/.vim-plug/neotest/lua/nio/tasks.lua:180>
```

[This](https://github.com/nvim-neotest/neotest/blob/1e67a504d03def3a6a1125d934cb511680f72555/lua/neotest/consumers/state/tracker.lua#L47) is the line where the tree is `nil`. I haven't been able to find an open/closed neotest issue that explains this.

I also get this traceback when using the upstream version of neotest-mocha so this might be a problem with what is passed to neotest or an issue with neotest itself. I do not get this issue with neotest-jest.

Strangely, if I open the summary before running the test, it runs as expected with no tracebacks...I'll try and spend some more time on the issue but it should not really be a blocker for this PR as the issue also exists in upstream neotest-mocha (at least on my machine).