### PR TITLE
Uniquely identify tests

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -30,8 +30,6 @@ jobs:
         include:
           - os: ubuntu-20.04
             url: https://github.com/neovim/neovim/releases/download/nightly/nvim-linux64.tar.gz
-          - os: ubuntu-20.04
-            url: https://github.com/neovim/neovim/releases/download/v0.7.0/nvim-linux64.tar.gz
     steps:
       - uses: actions/checkout@v3
       - run: date +%F > todays-date

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![build](https://github.com/adrigzr/neotest-mocha/actions/workflows/workflow.yaml/badge.svg)](https://github.com/adrigzr/neotest-mocha/actions/workflows/workflow.yaml)
 
-This plugin provides a Mocha adapter for the [Neotest](https://github.com/rcarriga/neotest) framework.
+This plugin provides a Mocha adapter for the [Neotest](https://github.com/rcarriga/neotest) framework. Requires at least version 4.0.0.
 
 **It is currently a work in progress**. It will be transferred to the official neotest organisation (once it's been created).
 

--- a/lua/neotest-mocha/init.lua
+++ b/lua/neotest-mocha/init.lua
@@ -175,12 +175,11 @@ function Adapter.build_spec(args)
   local pos = tree:data()
   local testNamePattern = "'.*'"
 
-  if pos.type == "test" then
-    testNamePattern = "'" .. util.escape_test_pattern(pos.name) .. "$'"
-  end
-
-  if pos.type == "namespace" then
-    testNamePattern = "'^" .. util.escape_test_pattern(pos.name) .. "'"
+  if pos.type == "test" or pos.type == "namespace" then
+    local testName = string.sub(pos.id, string.find(pos.id, "::") + 2)
+    testName, _ = string.gsub(testName, "::", " ")
+    testNamePattern = "'^" .. util.escape_test_pattern(testName)
+    testNamePattern = testNamePattern .. (pos.type == "test" and "$'" or "'")
   end
 
   local binary = get_mocha_command(pos.path)

--- a/lua/neotest-mocha/init.lua
+++ b/lua/neotest-mocha/init.lua
@@ -112,14 +112,14 @@ function Adapter.discover_positions(file_path)
     ; Matches: `it('test') / specify('test')`
     ((call_expression
       function: (identifier) @func_name (#any-of? @func_name "it" "specify")
-      arguments: (arguments [(template_string) @test.name (string (string_fragment) @test.name)]  [(arrow_function) (function)])
+      arguments: (arguments [(template_string) @test.name (string (string_fragment) @test.name)]  [(arrow_function) (function_expression)])
     )) @test.definition
     ; Matches: `it.only('test') / specify.only('test')`
     ((call_expression
       function: (member_expression
         object: (identifier) @func_name (#any-of? @func_name "it" "specify")
       )
-      arguments: (arguments [(template_string) @test.name (string (string_fragment) @test.name)]  [(arrow_function) (function)])
+      arguments: (arguments [(template_string) @test.name (string (string_fragment) @test.name)]  [(arrow_function) (function_expression)])
     )) @test.definition
   ]]
 

--- a/test/basic_spec.lua
+++ b/test/basic_spec.lua
@@ -148,7 +148,7 @@ describe("build_spec", function()
   async.it("builds command for a test", function()
     local tree = MockTree:new {
       {
-        id = "./test/specs/basic.test.js::describe suite::should pass",
+        id = "./test/specs/basic.test.js::describe-suite::should pass",
         name = "should pass",
         path = "./test/specs/basic.test.js",
         range = { 5, 2, 8, 4 },
@@ -160,7 +160,7 @@ describe("build_spec", function()
       "--full-trace",
       "--reporter=json",
       "--reporter-options=output=tempname.json",
-      "--grep='should pass$'",
+      "--grep='^describe\\-suite should pass$'",
       "./test/specs/basic.test.js",
     }
     local expected_cwd = nil


### PR DESCRIPTION
With the current implementation, running the test in either `suite 1` or `suite 2` will run the other test as well because the pattern that is constructed and passed to mocha doesn't account for the suite name.

```javascript
describe('top-level suite', () => {
  describe('suite 1', () => {
    it('tests a test', async () => {
      console.log("first test")
    })
  })
  describe('suite 2', () => {
    it('tests a test', async () => {
      console.log("second test")
    })
  })
})
```

These changes follow the code in [neotest-jest](https://github.com/nvim-neotest/neotest-jest/blob/main/lua/neotest-jest/init.lua#L381-L395) with some modification. Hopefully the code and test are straight-forward.

Failing test is related to neotest's treesitter module.