### PR TITLE
Allow passing a function for command arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,14 @@
 
 [![build](https://github.com/adrigzr/neotest-mocha/actions/workflows/workflow.yaml/badge.svg)](https://github.com/adrigzr/neotest-mocha/actions/workflows/workflow.yaml)
 
-This plugin provides a [Mocha](https://github.com/mochajs/mocha) adapter for the [Neotest](https://github.com/rcarriga/neotest) framework. Requires at least Neotest version 4.0.0 which in turn requires at least neovim version 0.9.0.
+This plugin provides a [Mocha](https://github.com/mochajs/mocha) adapter for the [Neotest](https://github.com/rcarriga/neotest) framework.
 
 **It is currently a work in progress**. It will be transferred to the official neotest organisation (once it's been created).
+
+## Requirements
+
+* At least Neotest version 4.0.0 which in turn requires at least neovim version 0.9.0.
+* At least mocha v9.1.0.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,23 @@ use({
       adapters = {
         require('neotest-mocha')({
           command = "npm test --",
+          command_args = function(context)
+            -- The context contains:
+            --   results_path: The file that json results are written to
+            --   test_name_pattern: The generated pattern for the test
+            --   path: The path to the test file
+            --
+            -- It should return a string array of arguments
+            --
+            -- Not specifying 'command_args' will use the defaults below
+            return {
+                "--full-trace",
+                "--reporter=json",
+                "--reporter-options=output=" .. context.results_path,
+                "--grep=" .. context.test_name_pattern,
+                context.path,
+            }
+          end,
           env = { CI = true },
           cwd = function(path)
             return vim.fn.getcwd()

--- a/lua/neotest-mocha/init.lua
+++ b/lua/neotest-mocha/init.lua
@@ -10,7 +10,7 @@ local util = require "neotest-mocha.util"
 
 ---@class neotest.MochaOptions
 ---@field command? string|fun(path:string): string
----@field command_args? fun(context: neotest.MochaSpecContext): string[]
+---@field command_args? fun(context:neotest.MochaSpecContext): string[]
 ---@field env? table<string, string>|fun(): table<string, string>
 ---@field cwd? string|fun(): string
 ---@field is_test_file? fun(path:string): boolean
@@ -18,10 +18,10 @@ local util = require "neotest-mocha.util"
 ---@type fun(path:string):string
 local get_mocha_command = util.get_mocha_command
 
----@type fun(context:neotest.MochaSpecContext):string[]
+---@type fun(context:neotest.MochaSpecContext): string[]
 local get_mocha_command_args = util.get_mocha_command_args
 
----@type fun(env: string[]):table<string, string>|nil
+---@type fun(env:string[]): table<string, string>?
 local get_env = util.get_env
 
 ---@type fun(path:string):string|nil

--- a/lua/neotest-mocha/init.lua
+++ b/lua/neotest-mocha/init.lua
@@ -199,7 +199,9 @@ function Adapter.build_spec(args)
     path = pos.path,
   }
 
-  vim.list_extend(command, command_args)
+  if vim.tbl_islist(command_args) then
+    vim.list_extend(command, command_args)
+  end
 
   return {
     command = command,

--- a/lua/neotest-mocha/util.lua
+++ b/lua/neotest-mocha/util.lua
@@ -199,6 +199,18 @@ function M.get_mocha_command(path)
   return "mocha"
 end
 
+---@param context neotest.MochaSpecContext
+---@return string[]
+function M.get_mocha_command_args(context)
+  return {
+    "--full-trace",
+    "--reporter=json",
+    "--reporter-options=output=" .. context.results_path,
+    "--grep=" .. context.test_name_pattern,
+    context.path,
+  }
+end
+
 ---@param s string
 ---@return string
 function M.escape_test_pattern(s)

--- a/test/basic_spec.lua
+++ b/test/basic_spec.lua
@@ -218,7 +218,7 @@ describe("build_spec", function()
       "--bail",
       "--dry-run",
       "--reporter=spec",
-      "--grep='should pass$'",
+      "--grep='^describe suite should pass$'",
       "./test/specs/basic.test.js",
     }
     local expected_cwd = nil


### PR DESCRIPTION
Closes #12.

I decided to only allow a function as an argument as passing a `string[]` directly wouldn't have the context of a `results_path` etc. Also since the `command` option is split on "%s+" which breaks strings like` --grep='this is a test pattern'`, I thought this would be more flexible.