### PR TITLE
Add v0.9.0 to workflow

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -30,6 +30,8 @@ jobs:
         include:
           - os: ubuntu-20.04
             url: https://github.com/neovim/neovim/releases/download/nightly/nvim-linux64.tar.gz
+          - os: ubuntu-20.04
+            url: https://github.com/neovim/neovim/releases/download/v0.9.0/nvim-linux64.tar.gz
     steps:
       - uses: actions/checkout@v3
       - run: date +%F > todays-date

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![build](https://github.com/adrigzr/neotest-mocha/actions/workflows/workflow.yaml/badge.svg)](https://github.com/adrigzr/neotest-mocha/actions/workflows/workflow.yaml)
 
-This plugin provides a Mocha adapter for the [Neotest](https://github.com/rcarriga/neotest) framework. Requires at least version 4.0.0.
+This plugin provides a [Mocha](https://github.com/mochajs/mocha) adapter for the [Neotest](https://github.com/rcarriga/neotest) framework. Requires at least Neotest version 4.0.0 which in turn requires at least neovim version 0.9.0.
 
 **It is currently a work in progress**. It will be transferred to the official neotest organisation (once it's been created).
 


### PR DESCRIPTION
As per https://github.com/adrigzr/neotest-mocha/pull/13#issuecomment-1917015899, we should probably add 0.9.0 to the workflow.