### PR TITLE
fix: Add cwd to support js-debug-adapter

### DIFF
--- a/lua/neotest-mocha/init.lua
+++ b/lua/neotest-mocha/init.lua
@@ -203,14 +203,16 @@ function Adapter.build_spec(args)
     vim.list_extend(command, command_args)
   end
 
+  local cwd = get_cwd(pos.path)
+
   return {
     command = command,
-    cwd = get_cwd(pos.path),
+    cwd = cwd,
     context = {
       results_path = results_path,
       file = pos.path,
     },
-    strategy = util.get_strategy_config(args.strategy, command),
+    strategy = util.get_strategy_config(args.strategy, command, cwd),
     env = get_env(args[2] and args[2].env or {}),
   }
 end

--- a/lua/neotest-mocha/util.lua
+++ b/lua/neotest-mocha/util.lua
@@ -231,8 +231,9 @@ end
 
 ---@param strategy string
 ---@param command string[]
+---@param cwd string|nil
 ---@return table|nil
-function M.get_strategy_config(strategy, command)
+function M.get_strategy_config(strategy, command, cwd)
   local config = {
     dap = function()
       return {
@@ -243,6 +244,7 @@ function M.get_strategy_config(strategy, command)
         runtimeExecutable = command[1],
         console = "integratedTerminal",
         internalConsoleOptions = "neverOpen",
+        cwd = cwd or "${workspaceFolder}",
       }
     end,
   }


### PR DESCRIPTION
Addresses #18

Adds the `cwd` attribute to the debug config to allow for using `nvim-dap` to debug tests