### PR TITLE
Added test_name to the MochaSpecContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ use({
           command_args = function(context)
             -- The context contains:
             --   results_path: The file that json results are written to
+            --   test_name: The exact name of the test; is empty for `file` and `dir` position tests.
             --   test_name_pattern: The generated pattern for the test
             --   path: The path to the test file
             --

--- a/lua/neotest-mocha/init.lua
+++ b/lua/neotest-mocha/init.lua
@@ -5,6 +5,7 @@ local util = require "neotest-mocha.util"
 
 ---@class neotest.MochaSpecContext
 ---@field results_path string
+---@field test_name string
 ---@field test_name_pattern string
 ---@field path string
 
@@ -183,9 +184,10 @@ function Adapter.build_spec(args)
 
   local pos = tree:data()
   local testNamePattern = "'.*'"
+  local testName = ""
 
   if pos.type == "test" or pos.type == "namespace" then
-    local testName = string.sub(pos.id, string.find(pos.id, "::") + 2)
+    testName = string.sub(pos.id, string.find(pos.id, "::") + 2)
     testName, _ = string.gsub(testName, "::", " ")
     testNamePattern = "'^" .. util.escape_test_pattern(testName)
     testNamePattern = testNamePattern .. (pos.type == "test" and "$'" or "'")
@@ -195,6 +197,7 @@ function Adapter.build_spec(args)
   local command = vim.split(binary, "%s+")
   local command_args = get_mocha_command_args {
     results_path = results_path,
+    test_name = testName,
     test_name_pattern = testNamePattern,
     path = pos.path,
   }

--- a/test/basic_spec.lua
+++ b/test/basic_spec.lua
@@ -238,6 +238,54 @@ describe("build_spec", function()
     assert.equal(vim.inspect(expected_strategy), vim.inspect(spec.strategy))
     assert.equal(vim.inspect(expected_env), vim.inspect(spec.env))
   end)
+
+  async.it("builds command for a test with custom mocha arguments using test_name and fgrep", function()
+    local plugin = require_adapter {
+      command = "mocha",
+      command_args = function(context)
+        return {
+          "--bail",
+          "--dry-run",
+          "--reporter=spec",
+          "--fgrep=" .. context.test_name,
+          context.path,
+        }
+      end,
+    }
+    local tree = MockTree:new {
+      {
+        id = "./test/specs/basic.test.js::describe suite::should pass",
+        name = "should pass",
+        path = "./test/specs/basic.test.js",
+        range = { 5, 2, 8, 4 },
+        type = "test",
+      },
+    }
+    local expected_command = {
+      "mocha",
+      "--bail",
+      "--dry-run",
+      "--reporter=spec",
+      "--fgrep='describe suite should pass'",
+      "./test/specs/basic.test.js",
+    }
+    local expected_cwd = nil
+    local expected_context = {
+      results_path = "tempname.json",
+      file = "./test/specs/basic.test.js",
+    }
+    local expected_strategy = nil
+    local expected_env = {}
+
+    local spec = plugin.build_spec { tree = tree }
+
+    assert.is.truthy(spec)
+    assert.equal(vim.inspect(expected_command), vim.inspect(spec.command))
+    assert.equal(vim.inspect(expected_cwd), vim.inspect(spec.cwd))
+    assert.equal(vim.inspect(expected_context), vim.inspect(spec.context))
+    assert.equal(vim.inspect(expected_strategy), vim.inspect(spec.strategy))
+    assert.equal(vim.inspect(expected_env), vim.inspect(spec.env))
+  end)
 end)
 
 describe("results", function()


### PR DESCRIPTION
This allows the command_args to use the test name itself instead of just the pattern. This is useful, for example, if you wanted to use `fgrep` instead of `grep`.