### PR TITLE
fix(compat): fix Neovim 0.12 async context compatibility

### DIFF
--- a/lua/neotest-mocha/util.lua
+++ b/lua/neotest-mocha/util.lua
@@ -64,7 +64,7 @@ M.path = (function()
   end
 
   local function path_join(...)
-    return table.concat(vim.tbl_flatten { ... }, "/")
+    return table.concat({ ... }, "/")
   end
 
   -- Traverse the path calling cb along the way.
@@ -136,7 +136,7 @@ M.path = (function()
 end)()
 
 function M.search_ancestors(startpath, func)
-  validate { func = { func, "f" } }
+  validate { func = { func, "function" } }
   if func(startpath) then
     return startpath
   end
@@ -155,7 +155,7 @@ function M.search_ancestors(startpath, func)
 end
 
 function M.root_pattern(...)
-  local patterns = vim.tbl_flatten { ... }
+  local patterns = { ... }
   local function matcher(path)
     for _, pattern in ipairs(patterns) do
       for _, p in ipairs(vim.fn.glob(M.path.join(path, pattern), true, true)) do

--- a/test/basic_spec.lua
+++ b/test/basic_spec.lua
@@ -288,6 +288,20 @@ describe("build_spec", function()
   end)
 end)
 
+describe("has_package_dependency", function()
+  async.it("returns true when package is in devDependencies", function()
+    assert.True(util.has_package_dependency(".", "mocha"))
+  end)
+
+  async.it("returns false when package is not in dependencies", function()
+    assert.False(util.has_package_dependency(".", "jest"))
+  end)
+
+  async.it("returns false when package.json does not exist", function()
+    assert.False(util.has_package_dependency("/nonexistent/path", "mocha"))
+  end)
+end)
+
 describe("results", function()
   async.it("return results from test output", function()
     local plugin = require_adapter { command = "mocha" }

--- a/test/init.vim
+++ b/test/init.vim
@@ -1,4 +1,6 @@
 set runtimepath+=.
 set runtimepath+=../plenary.nvim
 set runtimepath+=../nvim-treesitter
+set runtimepath+=../nvim-nio
+set runtimepath+=../neotest
 runtime! plugin/plenary.vim


### PR DESCRIPTION
- Replace `vim.tbl_flatten` in `path_join` and `root_pattern` with plain table constructors. In Neovim 0.12, the deprecation shim calls `nvim_get_option_value` which is forbidden in fast/async event contexts, causing `is_test_file` to crash for every file and discover no test files at all.
- Call `lib.files.read` directly instead of wrapping it in `pcall`. The function is async (yields via `nio.uv`) and LuaJIT cannot yield across a C-call boundary like `pcall`, so the read always failed with the "cannot read package.json" warning.